### PR TITLE
Add lang attribute to html tag

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,24 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+/* This document is needed because it's the simplest way to alter
+ * surrounding HTML tags like <html> and <body>. See the documentation:
+ * 
+ * https://nextjs.org/docs/advanced-features/custom-document
+ */
+
+class MyDocument extends Document {
+  render() {
+    return (
+      // we set the lang attribute here for acessability
+      <Html lang="de">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -9,7 +9,7 @@ import Document, { Html, Head, Main, NextScript } from 'next/document'
 class MyDocument extends Document {
   render() {
     return (
-      // we set the lang attribute here for acessibility
+      // we set the lang attribute here for accessibility
       <Html lang="de">
         <Head />
         <body>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -9,7 +9,7 @@ import Document, { Html, Head, Main, NextScript } from 'next/document'
 class MyDocument extends Document {
   render() {
     return (
-      // we set the lang attribute here for acessability
+      // we set the lang attribute here for acessibility
       <Html lang="de">
         <Head />
         <body>


### PR DESCRIPTION
Referencing a Slack thread about accessibility, [I checked our current website with WAVE](https://wave.webaim.org/report#/http://iwi-hka.de). We have only one error, which is fixed with this PR. The rest are hints for improvement and can probably be postponed as they're not very urgent (heading hierarchy, links to the same page twice etc.). Please have a look and let me know if there are other areas of a11y that we should fix before merging this.