### PR TITLE
Implement spam prevention by using PHP script

### DIFF
--- a/content/pages/erstiinfos.md
+++ b/content/pages/erstiinfos.md
@@ -44,7 +44,7 @@ Für Fragen rund ums Studium und darüber hinaus besuche gerne unsere
 Ansonsten erreichst du uns hier:
 
 [icon:discord|Discord-Server](https://discord.gg/Ud5KQnz)
-[icon:at|kontakt@iwi-hka.de](kontakt@iwi-hka.de)
+[icon:at|E-Mail schreiben](/scripts/email.php?address=kontakt)
 
 ## O-Phase
 
@@ -135,7 +135,7 @@ Falls du für die O-Phase einen Schlafplatz in Karlsruhe brauchst, melde dich
 einfach bei uns unter der folgenden Mail. Sag uns, wer du bist und für wann du
 einen Schlafplatz benötigst.
 
-[icon:at|kontakt@iwi-hka.de](kontakt@iwi-hka.de)
+[icon:at|E-Mail schreiben](/scripts/email.php?address=kontakt)
 
 <br></br>
 
@@ -187,8 +187,8 @@ Moltkestr. 30, 76133 Karlsruhe<br />
 [icon:at|iz-benutzerberatung@hs-karlsruhe.de](iz-benutzerberatung@hs-karlsruhe.de)
 
 #### Fragen?
-Habt ihr noch Fragen oder Probleme? Dann meldet euch in der What's App Gruppe oder schreibt eine Mail an 
-[icon:at|kontakt@iwi-hka.de](kontakt@iwi-hka.de)
+Habt ihr noch Fragen oder Probleme? Dann meldet euch in der What's App Gruppe oder schreibt eine Mail!
+[icon:at|E-Mail schreiben](/scripts/email.php?address=kontakt)
 
 <!--## Mehr für Dich -->
 

--- a/content/pages/impressum.md
+++ b/content/pages/impressum.md
@@ -15,7 +15,7 @@ Vertreten durch: Simon Kienzler, Anja Buchmaier
 
 ### Kontakt
 
-[icon:at|kontakt@hska.info](mailto:kontakt@hska.info)
+[icon:at|E-Mail schreiben](/scripts/email.php?address=kontakt)
 
 [icon:phone|+49 721 925-1449](tel:+497219251449)
 

--- a/content/pages/kontakt.md
+++ b/content/pages/kontakt.md
@@ -14,9 +14,7 @@ Moltkestraße 30<br />
 76133 Karlsruhe<br />
 Raum E013
 
-[icon:at|kontakt@hska.info](mailto:kontakt@hska.info)
-
-[icon:at|mail@wi-fachschaft.de](mailto:mail@wi-fachschaft.de)
+[icon:at|E-Mail schreiben](/scripts/email.php?address=kontakt)
 
 [icon:phone|+49 721 925-1449](tel:+497219251449)
 
@@ -26,4 +24,4 @@ Raum E013
 
 Für Sponsoring und Kooperationsanfragen:
 
-[icon:at|sponsoring@hska.info](mailto:sponsoring@hska.info)
+[icon:at|E-Mail an das Sponsoring-Team schreiben](/scripts/email.php?address=sponsoring)

--- a/content/pages/unternehmen.md
+++ b/content/pages/unternehmen.md
@@ -51,5 +51,5 @@ Interesse an einer längeren Kooperation mit unserer Fachschaft Informatik &
 Wirtschaftsinformatik? Dann können Sie uns gerne über Mail oder Telefon
 kontaktieren.
 
-[icon:at|sponsoring@hska.info](mailto:sponsoring@hska.info)
+[icon:at|Mail an das Sponsoring-Team](/scripts/email.php?address=sponsoring)
 [icon:phone|+49 721 925-1449](tel:+497219251449)

--- a/content/pages/vorkurs.md
+++ b/content/pages/vorkurs.md
@@ -84,9 +84,9 @@ Kenntnisse auffrischen wollen.
 ## Anmeldung
 
 Du möchtest dabei sein? Super. Sende eine E-Mail mit einer kurzen Nachricht und
-deinem Studiengang an folgende E-Mail-Adresse:
+deinem Studiengang:
 
-[icon:at|vorkurs@iwi-hka.de](mailto:vorkurs@iwi-hka.de)
+[icon:at|Per Mail zum Vorkurs anmelden](/scripts/email.php?address=vorkurs)
 
 ## Benötigte Software
 

--- a/content/pages/werwirsind.md
+++ b/content/pages/werwirsind.md
@@ -83,6 +83,6 @@ Wenn ihr Interesse habt Teil der Fachschaft zu werden könnt ihr euch jeden Mitt
 
 ### Schreibt uns oder klingelt durch unter:
 
-[icon:at|kontakt@iwi-hka.de](kontakt@iwi-hka.de)
+[icon:at|E-Mail schreiben](/scripts/email.php?address=kontakt)
 
 [icon:phone|+49 721 925-1449](tel:+497219251449)

--- a/docs/content.md
+++ b/docs/content.md
@@ -62,6 +62,23 @@ Next.js, will only render something if it's present in the pages directory.
 
 Open the file, change what you want to change.
 
+## Linking to an E-Mail Address
+
+`mailto:` links are handy, but they attract spam bots that crawl websites for
+e-mail addresses. Therefore, we do not want to use e-mail addresses in our
+Markdown files. Instead, we have a script that you can link to. It will redirect
+to the users e-mail client, just like a regular `mailto:` link would. Copy and
+paste the snippet you need:
+
+```markdown
+[E-Mail schreiben](/scripts/email.php?address=kontakt)
+[E-Mail an das Sponsoring-Team](/scripts/email.php?address=sponsoring)
+[Für den Vorkurs anmelden](/scripts/email.php?address=vorkurs)
+```
+
+Everything else is handled for you. This also works with IconLinks (see below)!
+Don't worry if this doesn't work with `npm run dev` locally, PHP is needed.
+
 ## Add Images
 
 You can add images in Markdown, like this:

--- a/public/scripts/email.php
+++ b/public/scripts/email.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This script can be set as the destination of links that are supposed to
+ * open the visitors e-mail client. Hardcoding mailto-links into the website
+ * makes them an easy target for spam bots. This technique hides the addresses
+ * behind a regular link to /scripts/email.php?address=<destination>
+ * 
+ * Just pick one of the predefined addresses by their identifier, e. g.
+ * 
+ *              [Send mail](/scripts/email.php?address=kontakt)
+ * 
+ * will open the e-mail client with the kontakt@iwi-hka.de address filled in.
+ */
+
+if(isset($_GET['address'])) {
+    switch ($_GET['address']) {
+        case 'kontakt':
+            $location = 'mailto:kontakt@iwi-hka.de';
+            break;
+        case 'sponsoring':
+            $location = 'mailto:sponsoring@iwi-hka.de';
+            break;
+        case 'vorkurs':
+            $location = 'mailto:vorkurs@iwi-hka.de';
+            break;
+        default:
+            $location = "https://iwi-hka.de";
+            break;
+    }
+}
+
+header("Location: " . $location);


### PR DESCRIPTION
Fixes #12 

A simple PHP script is referenced whenever a `mailto:` link is desired. The script allows for a set of predefined e-mail addresses to be referenced by GET parameter. Further e-mail addresses can be added in the future.

Includes documentation. All existing e-mail addresses in Markdown files have been swapped out.

Acceptance criteria:

- [ ] Reviewers have approved that a hint in the documentation is enough, and we don't need a git pre-commit hook.
- [x] @milbegreif has confirmed that PHP is avilable on the production server. Otherwise this will not work. 