### PR TITLE
Fix routing of overview pages like FAQ and News

### DIFF
--- a/components/common/footer.tsx
+++ b/components/common/footer.tsx
@@ -21,7 +21,7 @@ function Footer() {
             </div>
             <p className="copyright my-4">
                 &copy; { new Date().getFullYear() } Fachschaft IWI<br /> 
-                <Link href="/impressum"><a className="text-gray-700 no-underline">Impressum</a></Link>
+                <Link href="/impressum/"><a className="text-gray-700 no-underline">Impressum</a></Link>
             </p>
         </footer>
     )

--- a/components/common/menu.tsx
+++ b/components/common/menu.tsx
@@ -9,11 +9,11 @@ function Menu() {
             </a></Link>
             <ul className="flex list-none">
                 { menuItem("Aktuelles","/") }
-                { menuItem("Erstsemester","/erstiinfos") }
-                { menuItem("Wer sind wir?","/werwirsind") }
-                { menuItem("Wissenswertes","/faq",) }
-                { menuItem("Sponsoring & Kooperation","/unternehmen",) }
-                { menuItem("Kontakt","/kontakt",) }
+                { menuItem("Erstsemester","/erstiinfos/") }
+                { menuItem("Wer sind wir?","/werwirsind/") }
+                { menuItem("Wissenswertes","/faq/",) }
+                { menuItem("Sponsoring & Kooperation","/unternehmen/",) }
+                { menuItem("Kontakt","/kontakt/",) }
             </ul>
             <Link href="/"><a>
                 <img src="/assets/user.png" alt="Zugang zum internen Bereich" className="h-8"/>

--- a/components/faq/post.tsx
+++ b/components/faq/post.tsx
@@ -15,7 +15,7 @@ function FaqPost({
                     content={content}
                 />
             </div>
-            <BackButton href='/faq' />
+            <BackButton href='/faq/' />
         </>
     )
 }

--- a/components/faq/tile.tsx
+++ b/components/faq/tile.tsx
@@ -6,7 +6,7 @@ function FaqTile({
     image,
 }) {
     return ( 
-        <Link as={`/faq/${ slug }`} href="/faq/[slug]">
+        <Link as={`/faq/${ slug }/`} href="/faq/[slug]/">
             <div
                 className="flex items-center flex-col justify-center cursor-pointer"
                 style={{

--- a/components/news/excerpt.tsx
+++ b/components/news/excerpt.tsx
@@ -10,13 +10,13 @@ function NewsExcerpt({
     return ( 
         <div className="w-10/12">
             <h3>
-                <Link as={`/news/${ slug }`} href="/news/[slug]">
+                <Link as={`/news/${ slug }/`} href="/news/[slug]/">
                     <a className="text-gray-700 no-underline">{ title }</a> 
                 </Link> 
             </h3>
             <p className="mb-8"> 
                 { excerpt }&nbsp;
-                <Link as={`/news/${ slug }`} href="/news/[slug]">
+                <Link as={`/news/${ slug }/`} href="/news/[slug]/">
                     <a className="text-blue-700 underline">Weiterlesen</a> 
                 </Link>
             </p> 

--- a/content/news/neue-website-online.md
+++ b/content/news/neue-website-online.md
@@ -30,17 +30,17 @@ eigentlichen Inhalte.
 
 Der Arbeitskreis Website der Fachschaft IWI machte sich in den Semesterferien
 daran, die Seite mit Inhalten und damit auch mit Leben zu füllen. Die
-[wichtigen Infos rund um's Studium](/faq) wurden ebenso eingepflegt wie die
-[Info-Seite zur Fachschaft selbst](/werwirsind) und natürlich die essentiellen
-[Infos für Studienanfänger:innen](/erstiinfos). Auch Unternehmen können sich auf
-der neu erstellten [Kooperations- und Sponsoring-Seite](/unternehmen)
+[wichtigen Infos rund um's Studium](/faq/) wurden ebenso eingepflegt wie die
+[Info-Seite zur Fachschaft selbst](/werwirsind/) und natürlich die essentiellen
+[Infos für Studienanfänger:innen](/erstiinfos/). Auch Unternehmen können sich auf
+der neu erstellten [Kooperations- und Sponsoring-Seite](/unternehmen/)
 informieren und mit uns in Kontakt treten.
 
 ### Verbesserungsvorschläge? Feedback? Mitmachen?
 
 Als Fachschaftlerinnen und Fachschaftler sind wir ehrenamtlich unterwegs und
 freuen uns immer über neue Gesichter und motivierte Studierende. Tretet gerne
-mit uns in [Kontakt](/kontakt), wenn Ihr mitmachen möchtet.
+mit uns in [Kontakt](/kontakt/), wenn Ihr mitmachen möchtet.
 
 Sollte Euch auf dieser (zugebenenermaßen noch nicht komplett fertigen) Website
 etwas auffallen, das vermutlich nicht so sein sollte, freuen wir uns ebenfalls

--- a/content/news/o-phase-ws-2020.md
+++ b/content/news/o-phase-ws-2020.md
@@ -10,14 +10,14 @@ header:
   image: '/assets/backgrounds/erstiinfos.jpg'
 ---
 
-**Auf der [Ersti-Info-Seite](/erstiinfos) findet ihr ab sofort alle wichtigen
+**Auf der [Ersti-Info-Seite](/erstiinfos/) findet ihr ab sofort alle wichtigen
 Infos und Updates zur O-Phase, die am 12.10.2020 startet.**
 
 ### Updates auch kurzfristig möglich
 
 Bitte beachtet, dass durch die erschwerten Bedingungen in diesem Semester
 kurzfristige Änderungen am Plan möglich sind. Diese werden zentral auf der
-[Erstsemester-Seite](/erstiinfos) bekannt gegeben und gesondert hervorgehoben.
+[Erstsemester-Seite](/erstiinfos/) bekannt gegeben und gesondert hervorgehoben.
 Schaut dort regelmäßig vorbei. Für aktuelle Infos schaut auch auf unseren
 [Instagram-Account](https://www.instagram.com/iwi_fachschaft/).
 
@@ -25,6 +25,6 @@ Schaut dort regelmäßig vorbei. Für aktuelle Infos schaut auch auf unseren
 
 Wir freuen uns, euch als Fachschaft IWI an der Hochschule Karlsruhe begrüßen zu
 dürfen. Wenn Ihr noch nicht wisst, was die Fachschaft ist und tut,
-[informiert Euch gerne](/werwirsind). Vermutlich werden wir uns in Zukunft öfter
+[informiert Euch gerne](/werwirsind/). Vermutlich werden wir uns in Zukunft öfter
 sehen. Wir wünschen dir einen erfolgreichen Start ins Studium und sind
-[gerne für dich da](/kontakt)!
+[gerne für dich da](/kontakt/)!

--- a/content/pages/erstiinfos.md
+++ b/content/pages/erstiinfos.md
@@ -20,7 +20,7 @@ vorbei, um kein Update zu verpassen.**
 
 ### Programmiervorkurs
 
-Hier geht's zu deinem [Programmiervorkurs](/vorkurs). Der findet immer in den 2
+Hier geht's zu deinem [Programmiervorkurs](/vorkurs/). Der findet immer in den 2
 Wochen vor Vorlesungsbeginn statt. Genaueres dazu findest du auf der verlinkten
 Seite.
 

--- a/next.config.js
+++ b/next.config.js
@@ -5,5 +5,6 @@ module.exports = {
             use: 'raw-loader',
         })
         return config
-    }
+    },
+    exportTrailingSlash: true
 }

--- a/pages/news.tsx
+++ b/pages/news.tsx
@@ -1,0 +1,27 @@
+import { GetStaticProps } from 'next'
+import MarkdownLoader from '../components/util/markdown-loader'
+import StaticPage from '../components/common/static-page'
+
+/* TODO build a news archive here */
+
+function Page({content, data}) {
+    return (
+        <StaticPage
+            className=""
+            data={data}
+            content={content}
+        />
+    )
+}
+
+export default Page
+
+export const getStaticProps: GetStaticProps = async (context) => {
+    const markdown = await MarkdownLoader.single('pages', '404')
+    return { 
+        props: {
+            content: markdown.content,
+            data: markdown.data
+        }
+    }
+}


### PR DESCRIPTION
Fixes #28

We introduce NextJS's `addTrailingSlash: true` option. By doing this, e. g. `/faq.html` becomes `/faq/index.html` and therefore _iwi-hka.de/faq/_ will be accessible as a page without JavaScript routing. This necessitated adding a trailing slash to all internal links, which is why there are a lot of changes to Markdown and Typescript files in this PR.

The path `/news/` wasn't previously occupied by any page. As I didn't want to implement a news archive for this quick fix, I created a small 404 page. The news archive can be added later.

Please make sure you test this PR locally with `npm run build` before approving it to make sure the contents in the `out` directory are built correctly.