### PR TITLE
Replace GoTo-Link with Discord information

### DIFF
--- a/content/pages/werwirsind.md
+++ b/content/pages/werwirsind.md
@@ -79,7 +79,7 @@ nur gerne an den Sitzungen teilnehmt oder euch aktiv um einen Aufgabenbereich
 kümmern wollt, ihr seid bei uns immer herzlich willkommen. Ein guter Anfang ist
 auf jeden Fall mittwochs im dritten Block (ab 11:30 Uhr) in den Sitzungen vorbei
 zu schauen. __Aktuell finden die Sitzungen online statt. 
-Wenn ihr Interesse habt Teil der Fachschaft zu werden könnt ihr euch jeden Mittwoch ab 17:30 Uhr unter GoToMeeting (https://www.gotomeet.me/ZoeKammerdiener) einwählen.__
+Wenn ihr Interesse habt, Teil der aktiven Fachschaft zu werden, könnt ihr euch jeden Mittwoch ab 17:30 Uhr auf unserem "Event"-Discord-Server (https://discord.gg/FWvYtct) im entsprechenden Sprachchannel "Fachschaftssitzung" einwählen.__
 
 ### Schreibt uns oder klingelt durch unter:
 

--- a/content/pages/werwirsind.md
+++ b/content/pages/werwirsind.md
@@ -79,7 +79,7 @@ nur gerne an den Sitzungen teilnehmt oder euch aktiv um einen Aufgabenbereich
 kümmern wollt, ihr seid bei uns immer herzlich willkommen. Ein guter Anfang ist
 auf jeden Fall mittwochs im dritten Block (ab 11:30 Uhr) in den Sitzungen vorbei
 zu schauen. __Aktuell finden die Sitzungen online statt. 
-Wenn ihr Interesse habt, Teil der aktiven Fachschaft zu werden, könnt ihr euch jeden Mittwoch ab 17:30 Uhr auf unserem "Event"-Discord-Server (https://discord.gg/FWvYtct) im entsprechenden Sprachchannel "Fachschaftssitzung" einwählen.__
+Wenn ihr Interesse habt, Teil der aktiven Fachschaft zu werden, könnt ihr euch jeden Mittwoch ab 17:30 Uhr auf unserem "Event"-Discord-Server im entsprechenden Sprachchannel "Fachschaftssitzung" einwählen.__
 
 ### Schreibt uns oder klingelt durch unter:
 

--- a/content/pages/werwirsind.md
+++ b/content/pages/werwirsind.md
@@ -79,7 +79,8 @@ nur gerne an den Sitzungen teilnehmt oder euch aktiv um einen Aufgabenbereich
 kümmern wollt, ihr seid bei uns immer herzlich willkommen. Ein guter Anfang ist
 auf jeden Fall mittwochs im dritten Block (ab 11:30 Uhr) in den Sitzungen vorbei
 zu schauen. __Aktuell finden die Sitzungen online statt. 
-Wenn ihr Interesse habt, Teil der aktiven Fachschaft zu werden, könnt ihr euch jeden Mittwoch ab 17:30 Uhr auf unserem "Event"-Discord-Server im entsprechenden Sprachchannel "Fachschaftssitzung" einwählen.__
+Wenn du Interesse hast, Teil der aktiven Fachschaft zu werden, komm einfach zur Fachschaftssitzung.
+Immer Mittwochs ab 17:30 Uhr auf unserem "Event"-Discord-Server im Sprachchannel "Fachschaftssitzung".__
 
 ### Schreibt uns oder klingelt durch unter:
 


### PR DESCRIPTION
As the title says.

The only thing I'm unsure of is if we should display the invitation to the event server on our website...this would mean that anybody can join the server unsupervised -> potentially more work for the administrator/moderators (in case of misbehavior).