### PR TITLE
Improve calendar appearance

### DIFF
--- a/components/common/event-area.tsx
+++ b/components/common/event-area.tsx
@@ -3,6 +3,7 @@ import Calendar from 'react-calendar'
 import { useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
+import DateFormatter from '../util/date-formatter'
 
 /* The EventArea displays a Calendar on the left and,
  * depending on the selected date, single events on
@@ -23,12 +24,13 @@ function EventArea({ events }) {
 function displayEvents(events) {
     // we're using React state to change displayed
     // events and the selected date dynamically
-    const [eventsOnDate, setEvents] = useState([noEventsNotice()])
-    const [selectedDate, setDate] = useState(new Date())
+    const today = new Date()
+    const [eventsOnDate, setEvents] = useState(renderEvents(filterEvents(events, today),events))
+    const [selectedDate, setDate] = useState(today)
 
     function onDateChange(selectedDate) {
         const filteredEvents = filterEvents(events, selectedDate)
-        setEvents(renderEvents(filteredEvents))
+        setEvents(renderEvents(filteredEvents, events))
         setDate(selectedDate)
     }
 
@@ -68,11 +70,11 @@ function filterEvents(events, selectedDate) {
     })
 }
 
-function renderEvents(events) {
-    if(events.length == 0) {
-        return [noEventsNotice()]
+function renderEvents(filteredEvents, allEvents) {
+    if(filteredEvents.length == 0) {
+        return [noEventsNotice(allEvents)]
     }
-    return events.map(event => {
+    return filteredEvents.map(event => {
         return (
             <EventContainer event={event} />
         )
@@ -83,12 +85,31 @@ function dayHasEvent(date, events) {
     return filterEvents(events, date).length != 0
 }
 
-function noEventsNotice() {
+function noEventsNotice(allEvents) {
     return (
         <div key="no-events-notice">
             <p>
                 Keine Veranstaltungen an diesem Tag.
             </p>
+            { displayUpcomingEvents(allEvents) }
+        </div>
+    )
+}
+
+function displayUpcomingEvents(events) {
+    return (
+        <div>
+            <p><strong>Die nächsten Events</strong></p>
+            <ul>
+                { events.slice(0,3).map(event => {
+                    return (
+                        <li> 
+                            { DateFormatter.formatDateTime(event.start.dateTime) } Uhr:
+                            &nbsp;{ event.summary }
+                        </li> 
+                    )
+                })}
+            </ul>
         </div>
     )
 }

--- a/components/common/event-container.tsx
+++ b/components/common/event-container.tsx
@@ -21,7 +21,7 @@ function eventWithoutImage(event) {
                 { DateFormatter.formatDateTime(event.end.dateTime) } Uhr
             </p>
             <p><span className="font-heading text-blue-700">Wo:</span><br />
-                { event.location || "Keine Location angegeben" }
+                { createLinkIfLocationStartsWithHttp(event.location) || "Keine Location angegeben" }
             </p>
             <p>
                 <a className="text-blue-700" href={ event.htmlLink }>Im Kalender öffnen</a>
@@ -49,6 +49,12 @@ function eventWithImage(event) {
     )
 }
 
+function createLinkIfLocationStartsWithHttp(location: string) {
+    if (location != null && location.startsWith('http')) {
+        return <a className="text-blue-700" href={location} target="_blank">Online</a>
+    }
+    return location
+}
 
 
 export default EventContainer

--- a/docs/calendar-events.md
+++ b/docs/calendar-events.md
@@ -16,6 +16,14 @@ to be seen by anyone. This includes:
 * meetups
 * other public events organized by the university, AStA or us
 
+## Adding Events
+
+To add events to the Google calendar, you need access to it. Please ask the
+infrastructure team in Slack. When adding events that are held online, please
+add the Zoom, GotoMeeting, Teams or any other link as the "location". If a link
+is present in the location field, we display it as such. Links in the
+description are currently not clickable.
+
 ## Service Account and Calendar API
 
 The easiest workflow to read calendar events programmatically (without a

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -4,6 +4,7 @@
 
 * [Contribution Guidelines](contribute.md)
 * [Create and update content](content.md)
+* [Add events to the calendar](calendar-events.md#adding-events)
 
 ## Develop and Deploy
 


### PR DESCRIPTION
* If an event is happening on the very same day the user visits the website, it is immediately displayed. Fixes #56
* If an event has a link (more technically, a string starting with `http`) in the location field, we render it as a clickable link. Fixes #60
* If a day is selected that no events, we display the three next upcoming events. Fixes #61 

Please test and review.