### PR TITLE
fit heading for mobile version

### DIFF
--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -5,7 +5,7 @@ import MarkdownLoader from '../components/util/markdown-loader'
 function Faq({ faq }) {
     return (
         <>
-            <h2>Häufig gestellte Fragen &ndash; Beantwortet!</h2>
+            <h2>Häufig gestellte Fragen, beantwortet!</h2>
             <p className="mb-8">Wähle einen für dich interessanten Themenbereich:</p>
             <div className="grid grid-cols-3 gap-8">
                 {


### PR DESCRIPTION
The hypon looks strange on the mobile version.
Replaced it with a comma.

On Live:
![image](https://user-images.githubusercontent.com/61432429/115592777-f52b8000-a2d3-11eb-9461-32883c6ee1d1.png)
