### PR TITLE
Use fix version for download artifact action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
     needs: [build]
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v4
         with:
           name: out
           path: out


### PR DESCRIPTION
Maybe using latest master branch is not the best Idea? Not sure if it's the fix, but worth trying